### PR TITLE
Switch from winres to winresource dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ edition.workspace = true
 build = "src/build.rs"
 
 [build-dependencies]
-winres = "*"
+winresource = "*"
 
 [features]
 default = ["hook"]

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,7 +1,9 @@
-use winres;
+use winresource;
 
 fn main() {
-    let mut res = winres::WindowsResource::new();
-    res.set_icon("assets/icon.ico");
-    res.compile().unwrap();
+    if std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "windows" {
+        let mut res = winresource::WindowsResource::new();
+        res.set_icon("assets/icon.ico");
+        res.compile().unwrap();
+    }
 }


### PR DESCRIPTION
This PR switches `winres` dependency to `winresource` in order to fix compilation errors on Linux. `winresource` is exactly the same as `winres` except it's maintained, so that might fix some other issues I am unaware of as well :)

This primarily fixes compilation errors on non-Windows OS-es, and allows for Linux systems to cross-compile mintcat Windows binaries with the icon. I have also added a recommended check to prevent the icon from being added on Linux systems, since it's not applicable there.

With these changes applied, I have tested and successfully compiled mintcat on the following rust toolchains:
- `x86_64-pc-windows-gnu` (Linux host, Windows target)
- `x86_64-unknown-linux-gnu` (Linux host, Linux target)
- `x86_64-pc-windows-gnu` (Windows host, Windows target)
- `x86_64-pc-windows-msvc` (Windows host, Windows target)