### PR TITLE
右下角计数问题

### DIFF
--- a/src/pages/HomePage/HomeViewModel.ts
+++ b/src/pages/HomePage/HomeViewModel.ts
@@ -66,8 +66,14 @@ export class HomeViewModel extends BaseViewModel {
     public async setDisplayName(id: number, name: string): Promise<void> {
         await this.homeService.updateModDisplayName(id, name);
     }
-    public async setModEnabled(modId: number, enable: boolean): Promise<void> {
-        await this.homeService.setModEnabled(modId, enable);
+    /**
+     * 设置 mod 启用状态
+     * @param modId mod 的 ID
+     * @param enable 是否启用
+     * @param profileModId 可选的 profile_mods 表主键 ID，用于避免切换 profile 时的竞态条件
+     */
+    public async setModEnabled(modId: number, enable: boolean, profileModId?: number): Promise<void> {
+        await this.homeService.setModEnabled(modId, enable, profileModId);
     }
 
     public async setModUsedVersion(profileModId: number, version: string): Promise<void> {

--- a/src/pages/HomePage/TreeViewItem.tsx
+++ b/src/pages/HomePage/TreeViewItem.tsx
@@ -152,8 +152,9 @@ function ModTreeViewSwitch({nodeData, onCountLabelUpdate}) {
         setPendingEnabled(nodeData.modId, newChecked);
 
         // 2. 异步更新数据库（不清除缓存，等 treeData 刷新后自动清除）
+        // 使用 profileModId 来避免切换 profile 时的竞态条件
         const viewModel = await IoC.get(HomeViewModel);
-        await viewModel.setModEnabled(nodeData.modId, newChecked);
+        await viewModel.setModEnabled(nodeData.modId, newChecked, nodeData.profileModId);
 
         // 3. 只更新计数标签
         if (onCountLabelUpdate) {

--- a/src/services/HomeService.ts
+++ b/src/services/HomeService.ts
@@ -161,9 +161,23 @@ export class HomeService {
         await modsApi.updateMod(modId, { displayName: name });
     }
 
-    public async setModEnabled(modId: number, enable: boolean): Promise<void> {
-        const profile = await this.getActiveProfile();
+    /**
+     * 设置 mod 启用状态
+     * @param modId mod 的 ID
+     * @param enable 是否启用
+     * @param profileModId 可选的 profile_mods 表主键 ID，用于避免切换 profile 时的竞态条件
+     */
+    public async setModEnabled(modId: number, enable: boolean, profileModId?: number): Promise<void> {
         const profiles = await StorageAPI.getProfiles();
+        
+        // 如果提供了 profileModId，直接通过 ID 更新（避免竞态条件）
+        if (profileModId !== undefined) {
+            await profiles.setModEnabledById(profileModId, enable);
+            return;
+        }
+        
+        // 兼容旧调用方式：通过 profileId + modId 更新
+        const profile = await this.getActiveProfile();
         await profiles.setModEnabled(profile.id!, modId, enable);
     }
 

--- a/src/storage/dao/ProfileDAO.ts
+++ b/src/storage/dao/ProfileDAO.ts
@@ -503,6 +503,26 @@ export class ProfileDAO {
         }
     }
 
+    /**
+     * 通过 profile_mods.id 设置模组启用状态
+     * 这种方式可以避免切换 profile 时的竞态条件问题
+     */
+    public async setModEnabledById(profileModId: number, enabled: boolean): Promise<boolean> {
+        try {
+            const db = await getDb();
+            await db.update(profileMods)
+                .set({
+                    isEnabled: enabled,
+                    updatedAt: new Date()
+                })
+                .where(eq(profileMods.id, profileModId));
+            return true;
+        } catch (error) {
+            console.error(`设置配置文件模组启用状态失败 [ProfileModID: ${profileModId}]:`, error);
+            return false;
+        }
+    }
+
 
     /**
      * 更新配置文件中的模组设置


### PR DESCRIPTION
Fixes a race condition where rapidly switching profiles and toggling mod enabled state could lead to incorrect counts.

The issue occurred because `HomeService.setModEnabled` relied on `this.getActiveProfile()`, which could return a newly selected profile if the user switched profiles during the asynchronous update. This caused the database to attempt to update the wrong profile's mod status, leading to the right-bottom counter not updating correctly. The fix introduces `profileModId` to directly update the specific `profile_mods` entry, ensuring the update applies to the intended mod regardless of the currently active profile.

---
<a href="https://cursor.com/background-agent?bcId=bc-dad5dd04-a3ce-4ddc-aa8c-ffa6bdd42423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dad5dd04-a3ce-4ddc-aa8c-ffa6bdd42423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

