### PR TITLE
版本切换冲突

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -52,5 +52,7 @@
   "Clear Current Cache": "Clear Current Cache",
   "Clear Cache Warning": "This will delete all cache files in the current cache directory, including downloaded Mod files, image cache, and avatar cache. These files will need to be re-downloaded. Please proceed with caution!",
   "Clean Cache Success": "Cache cleared successfully",
-  "Clean Cache Failed": "Failed to clear cache"
+  "Clean Cache Failed": "Failed to clear cache",
+  "Version switch in progress": "Version switch in progress",
+  "Version switch failed": "Version switch failed"
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -150,6 +150,8 @@
   "Sandbox": "沙盒",
   "Game Not Closed": "游戏未关闭",
   "Switch Version": "切换版本",
+  "Version switch in progress": "版本切换进行中",
+  "Version switch failed": "版本切换失败",
   "Click or drag file to this area": "点击图标选择文件或拖动文件到窗口",
   "Selected Files": "已选文件",
   "Please input mod": "请输入 mod",

--- a/src/pages/HomePage/TreeViewItem.tsx
+++ b/src/pages/HomePage/TreeViewItem.tsx
@@ -34,6 +34,22 @@ const {useToken} = theme;
 // 模块级别的缓存，用于在虚拟列表滚动时保持 Switch 状态
 const pendingEnabledChanges = new Map<number, boolean>();
 
+// 模块级别的版本切换锁定，防止快速重复点击导致下载冲突
+// key: modId, value: { isProcessing: boolean, abortController?: AbortController }
+const versionSwitchLocks = new Map<number, { isProcessing: boolean; currentVersion?: string }>();
+
+export function getVersionSwitchLock(modId: number): { isProcessing: boolean; currentVersion?: string } {
+    return versionSwitchLocks.get(modId) || { isProcessing: false };
+}
+
+export function setVersionSwitchLock(modId: number, lock: { isProcessing: boolean; currentVersion?: string }): void {
+    versionSwitchLocks.set(modId, lock);
+}
+
+export function clearVersionSwitchLock(modId: number): void {
+    versionSwitchLocks.delete(modId);
+}
+
 export function getPendingEnabled(modId: number, defaultValue: boolean): boolean {
     return pendingEnabledChanges.has(modId)
         ? pendingEnabledChanges.get(modId)!
@@ -179,11 +195,19 @@ function ModTreeViewVersionSelect({nodeData}) {
     const [selectedVersion, setSelectedVersion] = useState<string>(
         nodeData.usedVersion === "" ? nodeData.fileVersion : nodeData.usedVersion
     );
+    // 追踪是否正在处理版本切换（下载中）
+    const [isProcessing, setIsProcessing] = useState(() => getVersionSwitchLock(nodeData.modId).isProcessing);
 
     // 同步外部 prop 变化（当 Tree 完整刷新时）
     React.useEffect(() => {
         setSelectedVersion(nodeData.usedVersion === "" ? nodeData.fileVersion : nodeData.usedVersion);
     }, [nodeData.usedVersion, nodeData.fileVersion]);
+
+    // 同步锁定状态
+    React.useEffect(() => {
+        const lock = getVersionSwitchLock(nodeData.modId);
+        setIsProcessing(lock.isProcessing);
+    }, [nodeData.modId]);
 
     let fileInfos: ModFile[] = [];
     const onDropdownVisibleChange = async (visible: boolean) => {
@@ -209,40 +233,69 @@ function ModTreeViewVersionSelect({nodeData}) {
         const fileInfo = JSON.parse(value);
         const newVersion = fileInfo.version || fileInfo.filename;
         
+        // 检查是否有正在进行的版本切换
+        const currentLock = getVersionSwitchLock(nodeData.modId);
+        if (currentLock.isProcessing) {
+            // 如果选择的版本与正在处理的版本相同，忽略此次点击
+            if (currentLock.currentVersion === newVersion) {
+                return;
+            }
+            // 如果选择了不同的版本，仍然阻止，但更新显示
+            await StatusBar.warning(`${t("Version switch in progress")}: ${nodeData.title}`);
+            return;
+        }
+        
+        // 设置锁定状态
+        setVersionSwitchLock(nodeData.modId, { isProcessing: true, currentVersion: newVersion });
+        setIsProcessing(true);
+        
         // 立即更新本地状态（乐观更新），让下拉框立即显示新选中的版本
         setSelectedVersion(newVersion);
         
         await StatusBar.info(`${t("Switch Version")}: ${nodeData.title} ${newVersion}`);
 
-        const viewModel = await IoC.get(HomeViewModel);
-        // Use profileModId (profile_mods.id) instead of key
-        if (nodeData.profileModId) {
-            await viewModel.setModUsedVersion(nodeData.profileModId, fileInfo.version);
-        }
-
-        const modItem = await getModById(nodeData.modId);
-        if (!modItem) return;
-
-        // Update modItem with new version and download info
-        const updatedModItem: CompleteModData = {
-            ...modItem,
-            version: {
-                ...modItem.version!,
-                currentVersion: newVersion
-            },
-            download: {
-                ...modItem.download!,
-                downloadUrl: fileInfo.download.binary_url,
-                downloadProgress: 0,
-                fileSize: fileInfo.filesize,
+        try {
+            const viewModel = await IoC.get(HomeViewModel);
+            // Use profileModId (profile_mods.id) instead of key
+            if (nodeData.profileModId) {
+                await viewModel.setModUsedVersion(nodeData.profileModId, fileInfo.version);
             }
-        };
 
-        await emitEvent("mod-treeview-update", {
-            modId: updatedModItem.modId!,
-            data: updatedModItem
-        });
-        await ModUpdateService.updateModFile(updatedModItem);
+            const modItem = await getModById(nodeData.modId);
+            if (!modItem) {
+                clearVersionSwitchLock(nodeData.modId);
+                setIsProcessing(false);
+                return;
+            }
+
+            // Update modItem with new version and download info
+            const updatedModItem: CompleteModData = {
+                ...modItem,
+                version: {
+                    ...modItem.version!,
+                    currentVersion: newVersion
+                },
+                download: {
+                    ...modItem.download!,
+                    downloadUrl: fileInfo.download.binary_url,
+                    downloadProgress: 0,
+                    fileSize: fileInfo.filesize,
+                }
+            };
+
+            await emitEvent("mod-treeview-update", {
+                modId: updatedModItem.modId!,
+                data: updatedModItem
+            });
+            await ModUpdateService.updateModFile(updatedModItem);
+        } catch (error) {
+            console.error("版本切换失败:", error);
+            await StatusBar.error(`${t("Version switch failed")}: ${nodeData.title}`);
+        } finally {
+            // 清除锁定状态
+            clearVersionSwitchLock(nodeData.modId);
+            setIsProcessing(false);
+        }
     }
 
     return (
@@ -255,6 +308,8 @@ function ModTreeViewVersionSelect({nodeData}) {
                 options={options}
                 onChange={onChange}
                 onOpenChange={onDropdownVisibleChange}
+                disabled={isProcessing}
+                loading={isProcessing}
         />
     );
 }


### PR DESCRIPTION
Prevent download progress conflicts when rapidly switching mod versions.

Rapidly clicking the mod version dropdown could trigger multiple simultaneous downloads, leading to conflicting progress displays. This PR introduces a module-level lock to ensure only one version switch operation (download) can occur at a time for a given mod, improving UI stability and user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a59c206-15e8-47b3-87d5-10b15c4084b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8a59c206-15e8-47b3-87d5-10b15c4084b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

